### PR TITLE
Fix broken link - let GitHub.com make the link :)

### DIFF
--- a/content/cloud-native/readme.md
+++ b/content/cloud-native/readme.md
@@ -1,7 +1,7 @@
 # FastTrack for Azure Live - Cloud Native sessions
 This table of contents links to the materials for the respective FTA Live session.
 
-- [AKS Networking](./aks-networking/readme.md)
-- [AKS Monitoring Patterns and Practices](./aks-monitoring/readme.md)
-- [AKS Operations](./aks-operations/readme.md)
-- [AKS Security Best Practices](./aks-security/readme.md)
+- [AKS Networking](./aks-networking/)
+- [AKS Monitoring Patterns and Practices](./aks-monitoring/)
+- [AKS Operations](./aks-operations/)
+- [AKS Security Best Practices](./aks-security/)


### PR DESCRIPTION
For AKS Operations, because the file is named `README.md` a link to `readme.md` will fail on Linux. Similar to an `index.html`, we can just leave it out and GitHub makes the proper link :)